### PR TITLE
update the top banner replacing "Smartphone" with "Cloud and IoT"

### DIFF
--- a/static/sass/_patterns_hero.scss
+++ b/static/sass/_patterns_hero.scss
@@ -2,7 +2,6 @@
   background-position: center center;
   background-repeat: no-repeat;
   background-size: 6rem;
-  color: transparent;
   display: inline-block;
   float: left;
   margin-right: 0;

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,7 +37,7 @@ OS, Linux, ディストリビューション, OpenStack, Ubuntu OpenStack, Ubunt
     <div class="row">
       <div class="col-12">
         <p class="p-heading--four">
-          クラウドからスマートフォンまで、あらゆるもので実行できる<br>オープン ソース ソフトウェア プラットフォーム
+          デスクトップ、クラウドからIoTまで、あらゆるもので実行できる<br>オープンソースソフトウェアプラットフォーム
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- remove "color: transparent" to not hide captions of the top banner
  even if it's not translated to Japanese, it shouldn't be scary

- update the leading text by following the equivalent text on www.ubuntu.com
  > Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things 

  * before: "クラウド(Cloud)からスマートフォン(Smartphone)まで"
  * after: "デスクトップ(Desktop)、クラウド(Cloud)からIoT(IoT)まで"

## QA

N/A

## Issue / Card

N/A

## Screenshots

before:
![screenshot-2017-10-31 ubuntu 1](https://user-images.githubusercontent.com/4356209/32216369-32668dba-be68-11e7-9e7a-32c2b47567fd.png)

after:
![screenshot-2017-10-31 ubuntu](https://user-images.githubusercontent.com/4356209/32216383-396682fa-be68-11e7-8802-fff37817bdf2.png)


