### PR TITLE
Add CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+version: 2
+
+defaults: &defaults
+  docker:
+    - image: canonicalwebteam/dev
+
+jobs:
+  python-tests:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: pip3 install -r requirements.txt
+      - run:
+          name: Run python tests
+          command: yarn test-py
+  python-lint:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Lint python code
+          command: yarn lint-py
+  scss-lint:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: yarn
+      - run:
+          name: Lint sass
+          command: yarn lint-scss
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - scss-lint
+      - python-lint
+      - python-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-sudo: required
-
-services:
-  - docker
-
-script:
-- ./run test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Django website for jp.ubuntu.com",
   "main": "index.js",
   "scripts": {
-    "test": "sass-lint static/**/*.scss --verbose --no-exit",
+    "test": "yarn run lint-scss && yarn run lint-py && yarn run test-py",
+    "lint-py": "flake8 --exclude '*env*,node_modules'",
+    "lint-scss": "sass-lint static/**/*.scss --verbose --no-exit",
+    "test-py": "python3 manage.py test",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle static/css/modules static/js/modules",
     "watch": "watch -p 'static/sass/**/*.scss' -c 'yarn run build'",
     "build": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' && postcss --use cssnano --dir static/minified 'static/css/**/*.css' && yarn run copy-3rd-party",


### PR DESCRIPTION
## Done

Add CircleCI workflow to the project. Steps added are:
- Python tests.
- Python lint
- Sass lint

## QA
Check the CI wokrflow under my CircleCI space.

OR

- Fork jp.ubuntu.com.
- Add this feature branch to your fork.
- Enable project in your own CircleCI space.
- Follow the steps in https://circleci.com/docs/2.0/examples/#section=configuration to trigger a build.
- Check the workflow ran properly.

## Issue / Card
Fixes https://github.com/ubuntudesign/base-squad/issues/209