### PR TITLE
Update the global-nav package to v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,9 @@
     "test-py": "python3 manage.py test",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle static/css/modules static/js/modules",
     "watch": "watch -p 'static/sass/**/*.scss' -c 'yarn run build'",
-    "build": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' && postcss --use cssnano --dir static/minified 'static/css/**/*.css' && yarn run copy-3rd-party",
+    "build": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' && postcss --use cssnano --dir static/minified 'static/css/**/*.css' && yarn run copy-3rd-party-js",
     "serve": "./entrypoint 0.0.0.0:$PORT",
-    "copy-3rd-party": "yarn run copy-3rd-party-js && yarn run copy-3rd-party-css",
-    "copy-3rd-party-js": "mkdir -p static/js/modules && cp node_modules/global-nav/build/js/global.js static/js/modules/",
-    "copy-3rd-party-css": "mkdir -p static/css/modules && cp node_modules/global-nav/build/css/main.css static/css/modules/"
+    "copy-3rd-party-js": "mkdir -p static/js/modules && cp node_modules/global-nav/dist/index.js static/js/modules/global.js"
   },
   "keywords": [
     "website",
@@ -31,7 +29,7 @@
   "dependencies": {
     "autoprefixer": "^6.3.1",
     "cssnano": "^3.10.0",
-    "global-nav": "^0.2.3",
+    "global-nav": "^1.2.1",
     "node-sass": "^4.5.3",
     "postcss-cli": "^4.1.0",
     "sass-lint": "^1.10.2",

--- a/templates/_base/footer.html
+++ b/templates/_base/footer.html
@@ -50,6 +50,6 @@ $.get(xml_feed, function (data) {
 </script>
 
 <script src="/static/js/modules/global.js"></script>
-<script>ubuntu.globalNav.setup();</script>
+<script>canonicalGlobalNav.createNav({maxWidth: '64.875rem'});</script>
 
 {% endblock footer %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1078,9 +1078,9 @@ glob@~3.1.21:
     inherits "1"
     minimatch "~0.2.11"
 
-global-nav@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/global-nav/-/global-nav-0.2.3.tgz#8f61296bbf3803fdcff1540399c0fcc526f355ed"
+global-nav@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/global-nav/-/global-nav-1.2.1.tgz#584f25a3dacbd972707657a1bfe0ccd086dc67e7"
 
 globals@^9.2.0:
   version "9.18.0"


### PR DESCRIPTION
## Done
Updated the global-nav package to the latest version [v1.2.1](https://www.npmjs.com/package/global-nav)

## QA
- Run `./run clean`
- Run `./run`
- Check there are no errors
- View the site and check the global nav looks correct
- Check the products and login menus work

## Issue / Card
Fixes https://github.com/canonical-websites/jp.ubuntu.com/issues/63

## Screenshots
![screenshot_2019-01-21 ubuntu](https://user-images.githubusercontent.com/1413534/51500663-c3f73900-1dc6-11e9-9188-b2081b185b47.png)

