### PR TITLE
Bumped global-nav version to inline-svgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "autoprefixer": "^9.0.0",
     "cssnano": "^3.10.0",
-    "global-nav": "^2.0.0",
+    "global-nav": "^2.0.1",
     "node-sass": "^4.5.3",
     "postcss-cli": "^4.1.0",
     "sass-lint": "^1.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1113,9 +1113,9 @@ glob@~3.1.21:
     inherits "1"
     minimatch "~0.2.11"
 
-global-nav@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/global-nav/-/global-nav-2.0.0.tgz#6956e79e187680ec63f9d24ca184c30c7be84a66"
+global-nav@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/global-nav/-/global-nav-2.0.1.tgz#59c2a97b67f36eba687dfe7388427c935c729739"
 
 globals@^9.2.0:
   version "9.18.0"


### PR DESCRIPTION
## Done

- upgraded package json to use the 2.0.1 version of the global-nav

## QA

- See that the global nav is using inline svgs for its images

