### PR TITLE
Remove cloudinary from pdf url

### DIFF
--- a/templates/openstack.html
+++ b/templates/openstack.html
@@ -373,7 +373,7 @@
   <section class="p-strip">
     <div class="row">
       <h3>OpenStackの詳細</h3>
-      <p><a href="{{ ASSET_SERVER_URL }}a1ab6a86-OpenStack-made-easy_eBook_jp_01.08.18.pdf" class="p-button--positive"><span class="p-link--external">ホワイトペーパーを読む</span></a></p>
+      <p><a href="https://assets.ubuntu.com/v1/a1ab6a86-OpenStack-made-easy_eBook_jp_01.08.18.pdf" class="p-button--positive"><span class="p-link--external">ホワイトペーパーを読む</span></a></p>
     </div>
   </section>
   <section class="p-strip--light">


### PR DESCRIPTION
## Done

- removed cloudinary from a pdf asset and pointed directly to the asset.u.c site

## QA

- download the branch
- go to /openstack
- test the openstack whitepaper and see that it downloads

## Issue / Card

Fixes #99

