### PR TITLE
Use right tags for Japan blog

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -33,7 +33,7 @@ set_handlers(app)
 app.register_blueprint(jp_website)
 
 blog = BlogExtension()
-blog.init_app(app, "Blog title", [2996], "jp.ubuntu.com", "/blog")
+blog.init_app(app, "Ubuntu blog", [3184], "lang:jp", "/blog")
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0")


### PR DESCRIPTION
# Summary

Use right tags for japan blog articles. Sources https://github.com/canonical-websites/jp.ubuntu.com/issues/46#issuecomment-453035883

# QA

- `./run`
- go to `/blog`
- Should have no articles for now.
- View should work