### PR TITLE
Includes the blog card group styling, and aligns the titles horizontally

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==1.0.2
 canonicalwebteam.http==1.0.1
+canonicalwebteam.blog==0.1.4
 talisker==0.11.1
 python-dateutil==2.8.0
-canonicalwebteam.blog==0.1.3
 raven[flask]==6.5.0
 prometheus_client==0.3.1

--- a/static/sass/_utility_crop.scss
+++ b/static/sass/_utility_crop.scss
@@ -1,0 +1,31 @@
+@mixin blog-u-crop {
+  // Crop to 16:9
+  .u-crop--16-9 {
+    position: relative;
+
+    &::before {
+      content: "";
+      display: block;
+      padding-top: 10rem;
+      width: 100%;
+    }
+
+    // Incase img isn't wrapped in a link
+    & a,
+    & img {
+      bottom: 0;
+      left: 0;
+      overflow: hidden;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+
+    & a {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      text-align: center;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -19,9 +19,12 @@
 @import 'patterns_blog-post';
 @import 'patterns_blog-card';
 
+@import 'utility_crop';
+
 @include blog-p-list;
 @include blog-p-post;
 @include blog-p-card;
+@include blog-u-crop;
 
 @include jp-p-cloud-tools;
 @include jp-p-contextual-footer;

--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -1,7 +1,7 @@
 <div class="col-4 blog-p-card--post">
   {% if article.categories[0] in used_categories %}
-    <header class="blog-p-card__header">
-      <h5 class="p-muted-heading u-no-margin--bottom">{{ used_categories[article.categories[0]].slug }}</h5>
+    <header class="blog-p-card__header blog-p-card__header--{{ groups[article.group].slug }}">
+      <h5 class="p-muted-heading u-no-margin--bottom">{{ groups[article.group].slug }}</h5>
     </header>
   {% endif %}
   <div class="blog-p-card__content">
@@ -23,7 +23,7 @@
     <h3 class="p-heading--four">
       <a href="/blog/{{ article.slug }}">{{ article.title.rendered|safe }}</a>
     </h3>
-    <p><em>by {{ article.author.name }} on {{ article.date }}</em></p>
+    <p><em>by <a href="https://blog.ubuntu.com/author/{{article.author.slug}}">{{ article.author.name }}</a> on {{ article.date }}</em></p>
     {% if not article.image %}
       <p class="u-no-padding--bottom">{{ article.excerpt.raw }}</p>
     {% endif %}


### PR DESCRIPTION
## Done

- Inlcudes the new version of the [blog flask extension](https://github.com/canonical-webteam/blog-flask-extension) which provides the correct article groups.
- uses the article groups to apply the correct styling
- aligns titles horizontally
- links author to author page on blog.ubuntu.com

## QA
![image](https://user-images.githubusercontent.com/2843450/53159836-90265380-35be-11e9-8c8c-92a230b95a31.png)


