### PR TITLE
Fix blog posts links in footers and feeds

### DIFF
--- a/tests/test_template_utils.py
+++ b/tests/test_template_utils.py
@@ -30,7 +30,7 @@ class TemplateUtilsTest(unittest.TestCase):
 
     def test_replace_admin(self):
         url = "https://admin.insights.ubuntu.com/test-url/123"
-        expected_result = "https://blog.ubuntu.com/test-url/123"
+        expected_result = "https://jp.ubuntu.com/blog/test-url/123"
 
         result = template_utils.replace_admin(url)
         self.assertEqual(expected_result, result)

--- a/webapp/template_utils.py
+++ b/webapp/template_utils.py
@@ -24,7 +24,7 @@ def format_date(date):
 
 
 def replace_admin(url):
-    return url.replace("admin.insights.ubuntu.com", "blog.ubuntu.com")
+    return url.replace("admin.insights.ubuntu.com", "jp.ubuntu.com/blog")
 
 
 def versioned_static(filename):

--- a/webapp/templatetags/utils.py
+++ b/webapp/templatetags/utils.py
@@ -24,4 +24,4 @@ def format_date(date):
 
 @register.filter
 def replace_admin(url):
-    return url.replace("admin.insights.ubuntu.com", "blog.ubuntu.com")
+    return url.replace("admin.insights.ubuntu.com", "jp.ubuntu.com/blog")


### PR DESCRIPTION
## Done

* Fixed 404 on blog posts links in footers by altering the defaults feed utils: "blog.ubuntu.com" -> "jp.ubuntu.com/blog"

## QA

Ensure links from footers (eg. bottom of `/download` page are pointing users at the correct location)
