### PR TITLE
Fix ubuntu server download links

### DIFF
--- a/templates/download.html
+++ b/templates/download.html
@@ -80,10 +80,10 @@
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
-      <h3 class="p-card__title">Ubuntu Server 18.04.1 LTS</h3>
+      <h3 class="p-card__title">Ubuntu Server 18.04.2 LTS</h3>
       <div class="p-card__content">
         <p>Ubuntu ServerのLTS版には、OpenStackのQueensリリースが含まれ、2023年4月までのサポートが保証されています。64ビット版のみの提供です。</p>
-        <p><a class="p-button--positive row" href="https://www.ubuntu.com/download/desktop/thank-you?version=18.04.1&architecture=amd64"><span class="p-link--external">ダウンロード</span></a></p>
+        <p><a class="p-button--positive row" href="https://www.ubuntu.com/download/server/thank-you?version=18.04.2&architecture=amd64"><span class="p-link--external">ダウンロード</span></a></p>
         <p><a class="p-link--external" href="https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes">Ubuntu 18.04 LTS release notes</a></p>
       </div>
     </div>
@@ -91,7 +91,7 @@
       <h3 class="p-card__title">Ubuntu Server 18.10</h3>
       <div class="p-card__content">
         <p>Ubuntu Serverの最新バージョンです。2019年7月までの9か月のセキュリティアップデートとメンテナンスアップデートが含まれます。</p>
-        <p><a class="p-button--neutral row" href="https://www.ubuntu.com/download/desktop/thank-you/?version=18.10&architecture=amd64"><span class="p-link--external">ダウンロード</span></a></p>
+        <p><a class="p-button--neutral row" href="https://www.ubuntu.com/download/server/thank-you/?version=18.10&architecture=amd64"><span class="p-link--external">ダウンロード</span></a></p>
         <p><a class="p-link--external" href="https://wiki.ubuntu.com/CosmicCuttlefish/ReleaseNotes">Ubuntu 18.10 release notes</a></p>
       </div>
     </div>


### PR DESCRIPTION
## Done

Fixed the download link for Ubuntu Server.
- Some links point to desktop versions.
- Replaced LTS to latest point release.

## QA

- Please check the download link
