### PR TITLE
Don't crash when a blog post is missing some category/type metadata

### DIFF
--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -28,7 +28,9 @@
       <p class="u-no-padding--bottom">{{ article.excerpt.raw }}</p>
     {% endif %}
   </div>
+  {% if article.categories[0] in used_categories %}
   <p class="blog-p-card__footer">
     {{ used_categories[article.categories[0]].name }}
   </p>
+  {% endif %}
 </div>


### PR DESCRIPTION
## Done

* Same as the card header: drop card footer when a blog post is mistakenly missing category/type metadata

## QA

* The demo page should work, not err 500
